### PR TITLE
Add simple FinBERT sentiment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,34 @@ Here are some ideas to get you started:
 - 😄 Pronouns: ...
 - ⚡ Fun fact: ...
 -->
+
+## FinBERT Sentiment Analyzer
+
+This repository includes a simple script (`finbert_analysis.py`) that uses the
+FinBERT model to classify financial text into the categories **Strong BUY**,
+**BUY**, **Neutral**, **SELL** and **Strong SELL**. It loads the model from the
+Hugging Face hub and can be run from the command line.
+
+### Requirements
+- Python 3.8+
+- `transformers` and `torch`
+
+Install the dependencies with:
+
+```bash
+pip install transformers torch
+```
+
+### Usage
+
+```bash
+python finbert_analysis.py "Your financial news or earnings report text here"
+```
+
+The script prints the sentiment label based on FinBERT's predictions. It adds
+`Strong` prefixes when the model is highly confident (>0.75 probability).
+
+### API Keys
+If you wish to integrate this script with external data sources, export your API
+key as an environment variable and modify the script accordingly. No external
+calls are performed by default.

--- a/finbert_analysis.py
+++ b/finbert_analysis.py
@@ -1,0 +1,63 @@
+import os
+from typing import List
+
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+import torch
+
+
+class FinBertAnalyzer:
+    """Analyze financial text using a FinBERT model."""
+
+    def __init__(self, model_name: str = "ProsusAI/finbert"):
+        # load tokenizer and model
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = AutoModelForSequenceClassification.from_pretrained(model_name)
+        self.model.eval()
+
+    def classify(self, text: str) -> str:
+        """Classify sentiment of the provided text.
+
+        Returns one of: 'Strong BUY', 'BUY', 'Neutral', 'SELL', 'Strong SELL'.
+        FinBERT predicts positive, neutral, or negative sentiment. This
+        function maps those predictions to more granular labels.
+        """
+        inputs = self.tokenizer(text, return_tensors="pt")
+        with torch.no_grad():
+            logits = self.model(**inputs).logits
+            scores = torch.softmax(logits, dim=1)[0]
+            label_id = torch.argmax(scores).item()
+
+        # FinBERT label order is: 0=neutral, 1=positive, 2=negative
+        mapping = {
+            0: "Neutral",
+            1: "BUY",
+            2: "SELL",
+        }
+        label = mapping.get(label_id, "Neutral")
+
+        # Add strong prefix when confidence is high
+        max_score = scores[label_id].item()
+        if max_score > 0.75:
+            if label == "BUY":
+                return "Strong BUY"
+            if label == "SELL":
+                return "Strong SELL"
+        return label
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Classify sentiment of financial text using FinBERT")
+    parser.add_argument("text", nargs="*", help="Text to analyze")
+    args = parser.parse_args()
+
+    if not args.text:
+        print("Please provide text to analyze.")
+        raise SystemExit(1)
+
+    analyzer = FinBertAnalyzer()
+    text = " ".join(args.text)
+    result = analyzer.classify(text)
+    print(f"Sentiment: {result}")
+


### PR DESCRIPTION
## Summary
- add basic FinBERT sentiment analysis script
- document usage in README

## Testing
- `python3 -m py_compile finbert_analysis.py`
- `python3 finbert_analysis.py "The company's revenue grew significantly and outlook is strong."` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68682a32b2648324b91fee478f19b5c9